### PR TITLE
Fix for coverty-scan detected defect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # massCorrelation
+
+[![Build Status](https://travis-ci.org/dvhh/massCorrelation.svg?branch=master)](https://travis-ci.org/dvhh/massCorrelation)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/5220/badge.svg)](https://scan.coverity.com/projects/5220)
+
 An exercise in writing an efficient correlation calculator
 
 ## Overview

--- a/src/massCorrelation.c
+++ b/src/massCorrelation.c
@@ -130,13 +130,13 @@ int main(int argc,char** argv) {
 
 	fprintf(stderr,"read %zu cols ,%zu rows\n",cols,rows);
 	//abort();
+	assert((SIZE_MAX/rows) > ((rows-1)/2));
+
 	float* outputData=getCorrelation(inputData,cols,rows);
 	free(inputData);
 
 	fprintf(stderr,"writing output data\n");
 
-	assert((SIZE_MAX/rows*2) > (rows-1));
-	
 	fwrite(outputData,sizeof(float),(rows*(rows-1)/2),output);
 	free(outputData);
 	if(outputPath!=NULL) {


### PR DESCRIPTION
move check for rows value before the correlation calculations,
modified the check to divide instead of multiply to avoid overflow

Added badges in the readme for coverty-scan and travis
